### PR TITLE
comment out example arena calls

### DIFF
--- a/entry/arenax/main.js
+++ b/entry/arenax/main.js
@@ -10,11 +10,14 @@ module.exports = {
     },
     render: function (width, height, elementId) {
       // Example of arena communication
+      /*
       let arenaXApi = ArenaXApi.getInstance()
       arenaXApi.dispatch({type: 'GAME_START', payload: null}) // notify arena that game started
       arenaXApi.dispatch({type: 'EVENT_CHANGE', payload: null}) // refresh display ads
       arenaXApi.dispatch({type: 'CHANGE_SCORE', payload: 1000}) // submit user score
       arenaXApi.dispatch({type: 'GAME_END', payload: null}) // notify arena that game ended
+      */
+
       // your render code goes here
       // make sure you render into elementId, either you can use initial width and height but make sure your game is dynamic
       // and can scale


### PR DESCRIPTION
Commented out example arena calls, so the page doesn't skip to the game end right away. Right now, even if you add render code in the entry main.js, the game will not be visible because the arena goes straight to the game end screen. They need to be removed first, which may be confusing.